### PR TITLE
Update deprecated ehrQL methods

### DIFF
--- a/analysis/dataset_definition_dm017.py
+++ b/analysis/dataset_definition_dm017.py
@@ -24,5 +24,6 @@ dataset.dm_reg_r2 = get_dm_reg_r2(dataset)
 # Define select rule 2
 has_dm_reg_select_r2 = dataset.dm_reg_r1 & ~dataset.dm_reg_r2
 
-# Apply business rules to set population
-dataset.set_population(has_registration & has_dm_reg_select_r2)
+
+# Apply business rules to define population
+dataset.define_population(has_registration & has_dm_reg_select_r2)

--- a/analysis/dataset_definition_dm020.py
+++ b/analysis/dataset_definition_dm020.py
@@ -64,8 +64,8 @@ has_dm020_select_r10 = (
     & ~dataset.dm020_r10
 )
 
-# Apply business rules to set population
-dataset.set_population(
+# Apply business rules to define population
+dataset.define_population(
     # Registration status
     has_registration
     # Business rules for DM_REG

--- a/analysis/dataset_definition_dm021.py
+++ b/analysis/dataset_definition_dm021.py
@@ -64,8 +64,8 @@ has_dm021_select_r10 = (
     & ~dataset.dm021_r10
 )
 
-# Apply business rules to set population
-dataset.set_population(
+# Apply business rules to define population
+dataset.define_population(
     # Registration status
     has_registration
     # Business rules for DM_REG

--- a/analysis/dm_dataset.py
+++ b/analysis/dm_dataset.py
@@ -32,7 +32,7 @@ def make_dm_dataset(index_date: date):
     dataset = Dataset()
 
     # Extract prior events for further use in variable definitions below
-    prior_events = clinical_events.take(
+    prior_events = clinical_events.where(
         clinical_events.date.is_on_or_before(index_date)
     )
 
@@ -113,7 +113,7 @@ def make_dm_dataset(index_date: date):
     # DMINVITE2_DAT: Date of the earliest invitation for a diabetes review
     # recorded at least 7 days after the first invitation and up to and
     # including the achievement date.
-    dminvite2_events = dminvite_events.take(
+    dminvite2_events = dminvite_events.where(
         dminvite_events.date.is_after(dataset.dminvite1_dat + days(7))
     )
     dataset.dminvite2_dat = (

--- a/analysis/variable_lib_helper.py
+++ b/analysis/variable_lib_helper.py
@@ -8,8 +8,8 @@ from databuilder.tables.beta import tpp as schema
 
 def first_matching_event(events, codelist, where=True):
     return (
-        events.take(where)
-        .take(events.snomedct_code.is_in(codelist))
+        events.where(where)
+        .where(events.snomedct_code.is_in(codelist))
         .sort_by(events.date)
         .first_for_patient()
     )
@@ -17,8 +17,8 @@ def first_matching_event(events, codelist, where=True):
 
 def last_matching_event(events, codelist, where=True):
     return (
-        events.take(where)
-        .take(events.snomedct_code.is_in(codelist))
+        events.where(where)
+        .where(events.snomedct_code.is_in(codelist))
         .sort_by(events.date)
         .last_for_patient()
     )
@@ -38,7 +38,7 @@ def died_as_of(date):
 
 def _registrations_overlapping_period(start_date, end_date):
     regs = schema.practice_registrations
-    return regs.take(
+    return regs.where(
         regs.start_date.is_on_or_before(start_date)
         & (regs.end_date.is_after(end_date) | regs.end_date.is_null())
     )
@@ -51,7 +51,7 @@ def practice_registration_as_of(date):
 
 def get_events_on_or_between(events, codelist, start_date, end_date, where=True):
     return (
-        events.take(where)
-        .take(events.snomedct_code.is_in(codelist))
-        .take(events.date.is_on_or_between(start_date, end_date))
+        events.where(where)
+        .where(events.snomedct_code.is_in(codelist))
+        .where(events.date.is_on_or_between(start_date, end_date))
     )


### PR DESCRIPTION
The following ehrQL methods have been updated:
- `.take` is now `.where` 
- `.drop` is now `.except_where` 
- `set_population` is now `.define_population`