### PR TITLE
Generate dataset for testing and measures for analysis

### DIFF
--- a/analysis/dataset_definition_dm017.py
+++ b/analysis/dataset_definition_dm017.py
@@ -25,11 +25,8 @@ dataset.dm_reg_r2 = get_dm_reg_r2(dataset)
 has_dm_reg_select_r2 = dataset.dm_reg_r1 & ~dataset.dm_reg_r2
 
 # Define DM017 numerator and denominator
-dm017_numerator = has_registration
-dm017_denominator = has_dm_reg_select_r2
-
-# Define variable with DM register population
-dataset.dm_reg_population = has_registration & has_dm_reg_select_r2
+dm017_numerator = has_dm_reg_select_r2
+dm017_denominator = has_registration
 
 # Define measures
 measures = Measures()

--- a/analysis/dataset_definition_dm020.py
+++ b/analysis/dataset_definition_dm020.py
@@ -71,19 +71,11 @@ has_dm020_select_r10 = (
     & ~dataset.dm020_r10
 )
 
-# Define DM020 numerator and denominator
+# Define DM020 denominator and numerator
+# DM020 gets applied to DM_REG (has_dm_reg_select_r2)
+# The numerator is applied to the patients selected into the denominator for this indicator.
 dm020_numerator = has_dm020_select_r2
-dm020_denominator = (has_dm020_select_r2 | has_dm020_select_r10)
-
-# Define dataset variable with DM020 population
-dataset.dm020_population = (
-    # Registration status
-    has_registration
-    # Select rules for DM_REG
-    & has_dm_reg_select_r2
-    # Select rules for DM020
-    & dm020_denominator
-)
+dm020_denominator = has_dm_reg_select_r2 & (has_dm020_select_r2 | has_dm020_select_r10)
 
 # Define measures
 measures = Measures()

--- a/analysis/dataset_definition_dm021.py
+++ b/analysis/dataset_definition_dm021.py
@@ -72,18 +72,10 @@ has_dm021_select_r10 = (
 )
 
 # Define DM021 numerator and denominator
+# DM021 gets applied to DM_REG (has_dm_reg_select_r2)
+# The numerator is applied to the patients selected into the denominator
 dm021_numerator = has_dm021_select_r2
-dm021_denominator = (has_dm021_select_r2 | has_dm021_select_r10)
-
-# Define dataset variable with DM021 population
-dataset.dm021_population = (
-    # Registration status
-    has_registration
-    # Select rules for DM_REG
-    & has_dm_reg_select_r2
-    # Select rules for DM021
-    & dm021_denominator
-)
+dm021_denominator = has_dm_reg_select_r2 & (has_dm021_select_r2 | has_dm021_select_r10)
 
 # Define measures
 measures = Measures()

--- a/lib/create_test_patients.r
+++ b/lib/create_test_patients.r
@@ -167,5 +167,5 @@ practice_registrations <- tibble::tribble(
            11, "2018-01-01",           NA,                   3,             3,          "region_practice3",
   )
 
-readr::write_csv(practice_registrations,here::here("dummy_data", "practice_registrations.csv"), na = "")
+readr::write_csv(practice_registrations, here::here("dummy_data", "practice_registrations.csv"), na = "")
 # nolint end

--- a/project.yaml
+++ b/project.yaml
@@ -7,40 +7,75 @@ actions:
 
 # Generate datasets
 ## DM017
-  generate_dataset_dm017:
+  test_dm017:
+    run: >
+      ehrql:v0 
+        generate-dataset analysis/dataset_definition_dm017.py
+        --dummy-tables dummy_data
+        --output output/datasets/dataset_dm017.csv
+    outputs:
+      moderately_sensitive:
+        cohort: output/datasets/dataset_dm017.csv
+
+  generate_measures_dm017:
     run: >
       ehrql:v0 
         generate-measures analysis/dataset_definition_dm017.py
         --dummy-tables dummy_data
-        --output output/measures/dataset_dm017.csv
+        --output output/measures/measures_dm017.csv
     outputs:
       moderately_sensitive:
-        cohort: output/measures/dataset_dm017.csv
+        cohort: output/measures/measures_dm017.csv
+
 
 ## DM020
-  generate_dataset_dm020:
+  test_dm020:
     run: >
       ehrql:v0 
-        generate-measures analysis/dataset_definition_dm020.py
+        generate-dataset analysis/dataset_definition_dm020.py
         --dummy-tables dummy_data
-        --output output/measures/dataset_dm020.csv
+        --output output/datasets/dataset_dm020.csv
         -- 
         --ifcchba-cutoff-val "58"
     outputs:
       moderately_sensitive:
-        cohort: output/measures/dataset_dm020.csv
+        cohort: output/datasets/dataset_dm020.csv
+  
+  generate_measures_dm020:
+    run: >
+      ehrql:v0 
+        generate-measures analysis/dataset_definition_dm020.py
+        --dummy-tables dummy_data
+        --output output/measures/measures_dm020.csv
+        -- 
+        --ifcchba-cutoff-val "58"
+    outputs:
+      moderately_sensitive:
+        cohort: output/measures/measures_dm020.csv
 
 
 ## DM021
-  generate_dataset_dm021:
+  test_dm021:
     run: >
       ehrql:v0 
-        generate-measures analysis/dataset_definition_dm021.py
+        generate-dataset analysis/dataset_definition_dm021.py
         --dummy-tables dummy_data
-        --output output/measures/dataset_dm021.csv
+        --output output/datasets/dataset_dm021.csv
         -- 
         --ifcchba-cutoff-val "75"
     outputs:
       moderately_sensitive:
-        cohort: output/measures/dataset_dm021.csv
+        cohort: output/datasets/dataset_dm021.csv
+  
+  generate_measures_dm021:
+    run: >
+      ehrql:v0 
+        generate-measures analysis/dataset_definition_dm021.py
+        --dummy-tables dummy_data
+        --output output/measures/measures_dm021.csv
+        -- 
+        --ifcchba-cutoff-val "75"
+    outputs:
+      moderately_sensitive:
+        cohort: output/measures/measures_dm021.csv
 

--- a/project.yaml
+++ b/project.yaml
@@ -7,15 +7,15 @@ actions:
 
 # Generate datasets
 ## DM017
-  test_dm017:
-    run: >
-      ehrql:v0 
-        generate-dataset analysis/dataset_definition_dm017.py
-        --dummy-tables dummy_data
-        --output output/datasets/dataset_dm017.csv
-    outputs:
-      moderately_sensitive:
-        cohort: output/datasets/dataset_dm017.csv
+  # test_dm017:
+  #   run: >
+  #     ehrql:v0 
+  #       generate-dataset analysis/dataset_definition_dm017.py
+  #       --dummy-tables dummy_data
+  #       --output output/datasets/dataset_dm017.csv
+  #   outputs:
+  #     moderately_sensitive:
+  #       cohort: output/datasets/dataset_dm017.csv
 
   generate_measures_dm017:
     run: >
@@ -29,17 +29,17 @@ actions:
 
 
 ## DM020
-  test_dm020:
-    run: >
-      ehrql:v0 
-        generate-dataset analysis/dataset_definition_dm020.py
-        --dummy-tables dummy_data
-        --output output/datasets/dataset_dm020.csv
-        -- 
-        --ifcchba-cutoff-val "58"
-    outputs:
-      moderately_sensitive:
-        cohort: output/datasets/dataset_dm020.csv
+  # test_dm020:
+  #   run: >
+  #     ehrql:v0 
+  #       generate-dataset analysis/dataset_definition_dm020.py
+  #       --dummy-tables dummy_data
+  #       --output output/datasets/dataset_dm020.csv
+  #       -- 
+  #       --ifcchba-cutoff-val "58"
+  #   outputs:
+  #     moderately_sensitive:
+  #       cohort: output/datasets/dataset_dm020.csv
   
   generate_measures_dm020:
     run: >
@@ -55,17 +55,17 @@ actions:
 
 
 ## DM021
-  test_dm021:
-    run: >
-      ehrql:v0 
-        generate-dataset analysis/dataset_definition_dm021.py
-        --dummy-tables dummy_data
-        --output output/datasets/dataset_dm021.csv
-        -- 
-        --ifcchba-cutoff-val "75"
-    outputs:
-      moderately_sensitive:
-        cohort: output/datasets/dataset_dm021.csv
+  # test_dm021:
+  #   run: >
+  #     ehrql:v0 
+  #       generate-dataset analysis/dataset_definition_dm021.py
+  #       --dummy-tables dummy_data
+  #       --output output/datasets/dataset_dm021.csv
+  #       -- 
+  #       --ifcchba-cutoff-val "75"
+  #   outputs:
+  #     moderately_sensitive:
+  #       cohort: output/datasets/dataset_dm021.csv
   
   generate_measures_dm021:
     run: >


### PR DESCRIPTION
This wont work but is just a commit to demonstrate my current ideas around testing:

To test the ehrQL logic and see all the variables that get created one would need to inspect an underlying dataset that gets used to calculate the measures. 

In ehrQL the underlying datasets don't get exposed to the researcher anymore when they use the `generate-measures` action. Also, the structure of the `dataset_definition.py` files is slightly different depending on which action gets used (no `dataset.define_population()` when using `generate-measures` action).

- Is there a good workflow that we can use to get an underlying dataset including all the variables specified in the dataset definition out of the `generate-measures` action?
- Or is there a way to use the same dataset definition for `generate-dataset` and `generate-measures` actions?