### PR TITLE
Generate dataset and measures for dm017

### DIFF
--- a/analysis/dataset_definition_dm017.py
+++ b/analysis/dataset_definition_dm017.py
@@ -1,3 +1,4 @@
+import sys
 from ehrql import INTERVAL, Measures, months
 from ehrql.tables.beta.tpp import patients
 
@@ -7,6 +8,9 @@ from dm_dataset import (
     get_dm_reg_r1,
     get_dm_reg_r2,
 )
+
+if len(sys.argv) > 2:
+    INTERVAL = INTERVAL.__class__(start_date=sys.argv[1], end_date=sys.argv[2])
 
 index_date = INTERVAL.start_date
 
@@ -27,6 +31,9 @@ has_dm_reg_select_r2 = dataset.dm_reg_r1 & ~dataset.dm_reg_r2
 # Define DM017 numerator and denominator
 dm017_numerator = has_dm_reg_select_r2
 dm017_denominator = has_registration
+
+if len(sys.argv) > 2:
+    dataset.define_population(dm017_denominator)
 
 # Define measures
 measures = Measures()

--- a/project.yaml
+++ b/project.yaml
@@ -5,36 +5,47 @@ expectations:
 
 actions:
 
+  generate_dataset_dm017_2022-03-01:
+    run: >
+      ehrql:v0 
+        generate-dataset analysis/dataset_definition_dm017.py
+        --dummy-tables dummy_data
+        --output output/datasets/dm017_dataset_2022-03-01.csv
+        -- 2022-03-01 2022-03-31
+    outputs:
+      highly_sensitive:
+        cohort: output/datasets/dm017_dataset_2022-03-01.csv
+
   generate_measures_dm017:
     run: >
       ehrql:v0 
         generate-measures analysis/dataset_definition_dm017.py
         --dummy-tables dummy_data
-        --output output/measures/measures_dm017.csv
+        --output output/measures/dm017_measures.csv
     outputs:
       moderately_sensitive:
-        cohort: output/measures/measures_dm017.csv
+        cohort: output/measures/dm017_measures.csv
   
   generate_measures_dm020:
     run: >
       ehrql:v0 
         generate-measures analysis/dataset_definition_dm020.py
         --dummy-tables dummy_data
-        --output output/measures/measures_dm020.csv
+        --output output/measures/dm020_measures.csv
         -- 
         --ifcchba-cutoff-val 58
     outputs:
       moderately_sensitive:
-        cohort: output/measures/measures_dm020.csv
+        cohort: output/measures/dm020_measures.csv
   
   generate_measures_dm021:
     run: >
       ehrql:v0 
         generate-measures analysis/dataset_definition_dm021.py
         --dummy-tables dummy_data
-        --output output/measures/measures_dm021.csv
+        --output output/measures/dm021_measures.csv
         -- 
         --ifcchba-cutoff-val 75
     outputs:
       moderately_sensitive:
-        cohort: output/measures/measures_dm021.csv
+        cohort: output/measures/dm021_measures.csv


### PR DESCRIPTION
We check if two dates are provided in `project.yaml` and if so assign them to be the start and end date of the interval. This allows us to generate a dataset and measures from the same dataset definition. We also need to do the same check for `.define_population()` because the measrues framework returns an error if `.define_population()` gets used.