### PR TITLE
Test ehrQL logic of indicator DM017

### DIFF
--- a/analysis/dataset_definition_dm017.py
+++ b/analysis/dataset_definition_dm017.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import date
 from ehrql import INTERVAL, Measures, months
 from ehrql.tables.beta.tpp import patients
 
@@ -12,7 +13,7 @@ from dm_dataset import (
 if len(sys.argv) > 2:
     INTERVAL = INTERVAL.__class__(start_date=sys.argv[1], end_date=sys.argv[2])
 
-index_date = INTERVAL.start_date
+index_date = INTERVAL.end_date
 
 # Instantiate dataset and define clinical variables
 dataset = make_dm_dataset(index_date=index_date)

--- a/analysis/dataset_definition_dm017.py
+++ b/analysis/dataset_definition_dm017.py
@@ -1,3 +1,4 @@
+import sys
 from ehrql import INTERVAL, Measures, months
 from ehrql.tables.beta.tpp import patients
 
@@ -7,6 +8,9 @@ from dm_dataset import (
     get_dm_reg_r1,
     get_dm_reg_r2,
 )
+
+if len(sys.argv) > 2:
+    INTERVAL = INTERVAL.__class__(start_date=sys.argv[1], end_date=sys.argv[2])
 
 index_date = INTERVAL.start_date
 
@@ -27,6 +31,9 @@ has_dm_reg_select_r2 = dataset.dm_reg_r1 & ~dataset.dm_reg_r2
 # Define DM017 numerator and denominator
 dm017_numerator = has_dm_reg_select_r2
 dm017_denominator = has_registration
+
+if len(sys.argv) > 2:
+    dataset.define_population(dm017_denominator)
 
 # Define measures
 measures = Measures()

--- a/analysis/dataset_definition_dm020.py
+++ b/analysis/dataset_definition_dm020.py
@@ -26,7 +26,7 @@ parser.add_argument("--ifcchba-cutoff-val", type=int)
 args = parser.parse_args()
 ifcchba_cutoff_val = args.ifcchba_cutoff_val
 
-index_date = INTERVAL.start_date
+index_date = INTERVAL.end_date
 
 # Instantiate dataset and define clinical variables
 dataset = make_dm_dataset(index_date=index_date)

--- a/analysis/dataset_definition_dm021.py
+++ b/analysis/dataset_definition_dm021.py
@@ -26,7 +26,7 @@ parser.add_argument("--ifcchba-cutoff-val", type=int)
 args = parser.parse_args()
 ifcchba_cutoff_val = args.ifcchba_cutoff_val
 
-index_date = INTERVAL.start_date
+index_date = INTERVAL.end_date
 
 # Instantiate dataset and define clinical variables
 dataset = make_dm_dataset(index_date=index_date)

--- a/analysis/test_dataset_definition_dm017.py
+++ b/analysis/test_dataset_definition_dm017.py
@@ -1,0 +1,79 @@
+from datetime import date
+from dataset_definition_dm017 import dataset
+
+from ehrql.codes import SNOMEDCTCode
+
+# Patient data for the FY22/23
+# Run the tests with the following command:
+# opensafely exec ehrql:v0 assure analysis/test_dataset_definition_dm017.py -- 2022-04-01 2023-03-31
+patient_data = {
+    # Correctly expected in population
+    1: {
+        "patients": [{"date_of_birth": date(1950, 1, 1)}],
+        "practice_registrations": [
+            {
+                "start_date": date(2010, 1, 1),
+                "end_date": date(2018, 1, 1),
+                "practice_pseudo_id": 1,
+                "practice_stp": 1,
+                "practice_nuts1_region_name": "region_practice1",
+            },
+            {
+                "start_date": date(2018, 1, 2),
+                "practice_pseudo_id": 3,
+                "practice_stp": 3,
+                "practice_nuts1_region_name": "region_practice3",
+            },
+        ],
+        "clinical_events": [{}],
+        "expected_columns": {
+            "reg_dat": date(2018, 1, 2),
+            "dereg_dat": None,
+            "pat_age": 73,
+            "dm_dat": None,
+            "dmlat_dat": None,
+            "dmres_dat": None,
+            "dm_reg_r1": None,
+            "dm_reg_r2": False,
+            },
+    },
+    2: {
+        "patients": [{"date_of_birth": date(1950, 1, 1)}],
+        "practice_registrations": [
+            {
+                "start_date": date(2019, 2, 1),
+                "end_date": None,
+                "practice_pseudo_id": 1,
+                "practice_stp": 1,
+                "practice_nuts1_region_name": "region_practice1",
+            },
+        ],
+        "clinical_events": [
+            {
+                # First diabetes diagnosis (DM_COD)
+                "date": date(2000, 6, 1),
+                "snomedct_code": "73211009",
+            },
+            {
+                # Last diabetes diagnosis (DM_COD)
+                "date": date(2023, 2, 1),
+                "snomedct_code": "73211009",
+            },
+            {
+                # Diabetes diagnosis resolved (DMRES_COD)
+                "date": date(2023, 1, 1),
+                "snomedct_code": "315051004",
+            },
+        ],
+        "expected_columns": {
+            "reg_dat": date(2019, 2, 1),
+            "dereg_dat": None,
+            "pat_age": 73,
+            "dm_dat": date(2000, 6, 1),
+            "dmlat_dat": date(2023, 2, 1),
+            "dmres_dat": date(2023, 1, 1),
+            "dm_reg_r1": True,
+            "dm_reg_r2": False,
+        },
+    },
+}

--- a/analysis/test_dataset_definition_dm017.py
+++ b/analysis/test_dataset_definition_dm017.py
@@ -26,6 +26,7 @@ patient_data = {
             },
         ],
         "clinical_events": [{}],
+        "expected_in_population": True,
         "expected_columns": {
             "reg_dat": date(2018, 1, 2),
             "dereg_dat": None,
@@ -35,9 +36,25 @@ patient_data = {
             "dmres_dat": None,
             "dm_reg_r1": None,
             "dm_reg_r2": False,
-            },
+        },
     },
+    # Correctly not expected in population
     2: {
+        "patients": [{"date_of_birth": date(2020, 1, 1)}],
+        "practice_registrations": [
+            {
+                "start_date": date(2010, 1, 1),
+                "end_date": date(2018, 1, 1),
+                "practice_pseudo_id": 1,
+                "practice_stp": 1,
+                "practice_nuts1_region_name": "region_practice1",
+            },
+        ],
+        "clinical_events": [{}],
+        "expected_in_population": False,
+    },
+    # Correctly expected in population
+    3: {
         "patients": [{"date_of_birth": date(1950, 1, 1)}],
         "practice_registrations": [
             {
@@ -65,6 +82,7 @@ patient_data = {
                 "snomedct_code": "315051004",
             },
         ],
+        "expected_in_population": True,
         "expected_columns": {
             "reg_dat": date(2019, 2, 1),
             "dereg_dat": None,

--- a/project.yaml
+++ b/project.yaml
@@ -5,36 +5,47 @@ expectations:
 
 actions:
 
+  generate_dataset_dm017_2022-03-01:
+    run: >
+      ehrql:v0 
+        generate-dataset analysis/dataset_definition_dm017.py
+        --dummy-tables dummy_data
+        --output output/datasets/dm017_dataset_2022-03-01.csv
+        -- 2022-03-01 2022-03-31
+    outputs:
+      highly_sensitive:
+        cohort: output/datasets/dm017_dataset_2022-03-01.csv
+
   generate_measures_dm017:
     run: >
       ehrql:v0 
         generate-measures analysis/dataset_definition_dm017.py
         --dummy-tables dummy_data
-        --output output/measures/measures_dm017.csv
+        --output output/measures/dm017_measures.csv
     outputs:
       moderately_sensitive:
-        cohort: output/measures/measures_dm017.csv
+        cohort: output/measures/dm017_measures.csv
   
   generate_measures_dm020:
     run: >
       ehrql:v0 
         generate-measures analysis/dataset_definition_dm020.py
         --dummy-tables dummy_data
-        --output output/measures/measures_dm020.csv
+        --output output/measures/dm020_measures.csv
         -- 
         --ifcchba-cutoff-val 58
     outputs:
       moderately_sensitive:
-        cohort: output/measures/measures_dm020.csv
+        cohort: output/measures/dm020_measures.csv
   
   generate_measures_dm021:
     run: >
       ehrql:v0 
         generate-measures analysis/dataset_definition_dm021.py
         --dummy-tables dummy_data
-        --output output/measures/measures_dm021.csv
+        --output output/measures/dm021_measures.csv
         -- 
         --ifcchba-cutoff-val 75
     outputs:
       moderately_sensitive:
-        cohort: output/measures/measures_dm021.csv
+        cohort: output/measures/dm021_measures.csv


### PR DESCRIPTION
Run the assurance tests (see documentation [here](https://docs.opensafely.org/ehrql/reference/cli/#assure)) for FY22/23:

```
opensafely exec ehrql:v0 assure analysis/test_dataset_definition_dm017.py -- 2022-04-01 2023-03-31
```

The first date after `--` indicates the start date for the measures framework, while the second date is the end date wich is also used as index date.